### PR TITLE
re-apply constructor role when extending another class

### DIFF
--- a/lib/MooX/StrictConstructor.pm
+++ b/lib/MooX/StrictConstructor.pm
@@ -54,6 +54,10 @@ use strictures 1;
 
 use Moo 1.001000 ();    # $Moo::MAKERS support
 use Moo::Role ();
+use Class::Method::Modifiers qw(install_modifier);
+
+use constant
+    CON_ROLE => 'Method::Generate::Constructor::Role::StrictConstructor';
 
 #
 # The gist of this code was copied directly from Graham Knop (HAARG)'s
@@ -67,10 +71,18 @@ sub import {
         die "MooX::StrictConstructor can only be used on Moo classes.";
     }
 
-    Moo::Role->apply_roles_to_object(
-        Moo->_constructor_maker_for($target),
-        'Method::Generate::Constructor::Role::StrictConstructor',
-    );
+    _apply_role($target);
+
+    install_modifier($target, 'after', 'extends', sub {
+        _apply_role($target);
+    });
+}
+
+sub _apply_role {
+    my $target = shift;
+    my $con = Moo->_constructor_maker_for($target);
+    Moo::Role->apply_roles_to_object($con, CON_ROLE)
+        unless Role::Tiny::does_role($con, CON_ROLE);
 }
 
 =head1 BUGS

--- a/t/basic.t
+++ b/t/basic.t
@@ -141,14 +141,11 @@ is( exception { OtherStrictSubclass->new( thing => 1, size => 'large', ) },
     q{strict subclass from parent that doesn't use strict constructor handles known attributes correctly}
 );
 
-TODO: {
-    local $TODO = "Can't deal with inherited constructor yet.";
-    like(
-        exception { OtherStrictSubclass->new( thing => 1, bad => 99 ) },
-        qr/unknown attribute.+: bad/,
-        q{strict subclass from parent that doesn't use strict correctly recognizes bad attribute}
-    );
-}
+like(
+    exception { OtherStrictSubclass->new( thing => 1, bad => 99 ) },
+    qr/unknown attribute.+: bad/,
+    q{strict subclass from parent that doesn't use strict correctly recognizes bad attribute}
+);
 
 TODO: {
     local $TODO = "Moose trick.  Doesn't work 'cuz my code runs before object built.";


### PR DESCRIPTION
This fixes applying StrictConstructor to a class that extends other classes.
