### PR TITLE
Improve clarity of errors and improve efficiency

### DIFF
--- a/lib/Method/Generate/Constructor/Role/StrictConstructor.pm
+++ b/lib/Method/Generate/Constructor/Role/StrictConstructor.pm
@@ -41,7 +41,7 @@ around _assign_new => sub {
     my \%attrs = (@attrs);
     my \@bad = sort grep { ! \$attrs{\$_} }  keys \%{ \$args };
     if (\@bad) {
-       die("Found unknown attribute(s) passed to the constructor: " .
+       Carp::confess("Found unknown attribute(s) passed to the constructor: " .
            join ", ", \@bad);
     }
 

--- a/lib/Method/Generate/Constructor/Role/StrictConstructor.pm
+++ b/lib/Method/Generate/Constructor/Role/StrictConstructor.pm
@@ -35,11 +35,13 @@ around _assign_new => sub {
         map  { $_->{init_arg} }    ## no critic (ProhibitAccessOfPrivateData)
         values(%$spec);
 
+    my $state = ($] >= 5.010) ? "use feature 'state'; state" : "my";
+
     my $body .= <<"EOF";
 
     # MooX::StrictConstructor
-    my \%attrs = (@attrs);
-    my \@bad = sort grep { ! \$attrs{\$_} }  keys \%{ \$args };
+    $state \$attrs = { @attrs };
+    my \@bad = sort grep { ! \$attrs->{\$_} }  keys \%{ \$args };
     if (\@bad) {
        Carp::confess("Found unknown attribute(s) passed to the constructor: " .
            join ", ", \@bad);

--- a/lib/Method/Generate/Constructor/Role/StrictConstructor.pm
+++ b/lib/Method/Generate/Constructor/Role/StrictConstructor.pm
@@ -30,7 +30,7 @@ around _assign_new => sub {
     my $self = shift;
     my $spec = $_[0];
 
-    my @attrs = map { B::perlstring($_) . ' => 1,' }
+    my @attrs = map { B::perlstring($_) . ' => undef,' }
         grep {defined}
         map  { $_->{init_arg} }    ## no critic (ProhibitAccessOfPrivateData)
         values(%$spec);
@@ -41,7 +41,7 @@ around _assign_new => sub {
 
     # MooX::StrictConstructor
     $state \$attrs = { @attrs };
-    my \@bad = sort grep { ! \$attrs->{\$_} }  keys \%{ \$args };
+    my \@bad = sort grep { ! exists \$attrs->{\$_} }  keys \%{ \$args };
     if (\@bad) {
        Carp::confess("Found unknown attribute(s) passed to the constructor: " .
            join ", ", \@bad);


### PR DESCRIPTION
This change give stack traces (like MooseX::StrictConstructor) so you can see the class and how new() came to be called with bad args.
Avoids the cost of rebuilding the valid-param-names hash. on. every. call. (for perl >= 5.10)
and reduces the memory cost of the hash.