### PR TITLE
Allow deleting arguments in BUILD to subvert strictness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-MooX-StrictConstructor-*/
-MooX-StrictConstructor-*tar.gz
-local/
-.envrc
+/MooX-StrictConstructor-*/
+/MooX-StrictConstructor-*tar.gz
+/local/
+/.envrc
+/.build

--- a/dist.ini
+++ b/dist.ini
@@ -10,15 +10,3 @@ AutoPrereqs.skip = ^Standard|Stricter$
 stopwords = BUILDARGS
 
 [MakeMaker]
-
-[Prereqs]
-indirect = 0
-multidimensional = 0
-bareword::filehandles = 0
-
-[Prereqs / TestRequires]
-Test::CPAN::Meta = 0
-Test::Pod::Coverage = 0
-Pod::Coverage::TrustPod = 0
-Test::Pod = 0
-

--- a/lib/Method/Generate/BuildAll/Role/StrictConstructor.pm
+++ b/lib/Method/Generate/BuildAll/Role/StrictConstructor.pm
@@ -1,0 +1,42 @@
+use strict;                     # redundant, but quiets perlcritic
+package Method::Generate::BuildAll::Role::StrictConstructor;
+use Moo::Role;
+
+has _constructor_generator => (is => 'rw', weaken => 1);
+
+sub _fake_BUILD {}
+
+around buildall_body_for => sub {
+  my ($orig, $self, $into, $me, $args, @extra) = @_;
+
+  my $con = $self->_constructor_generator;
+  my $real_build = ! do {
+    no strict 'refs'; ## no critic
+    defined &{"${into}::BUILD"} && \&{"${into}::BUILD"} == \&_fake_BUILD;
+  };
+
+  my $code = '';
+  if ($real_build) {
+    $code .= $self->$orig($into, $me, $args, @extra);
+  }
+  my $arg = $args =~ /^\$\w+$/ ? $args : "($args)[0]";
+  $code .=
+    '    if ( my @bad = grep { ! exists $MooX_StrictConstructor_attrs{$_} } keys %{'.$arg.'} ) {'."\n"
+    .'      Carp::croak("Found unknown attribute(s) passed to the constructor: " .'."\n"
+    .'        join(", ", sort @bad));'."\n"
+    .'    }'."\n";
+
+  my %captures = (
+    '%MooX_StrictConstructor_attrs' => {
+      map +($_ => 1),
+      grep defined,
+      map  $_->{init_arg},
+      values %{ $con->all_attribute_specs }
+    },
+  );
+
+  $con->_cap_call($code, \%captures);
+};
+
+1;
+__END__

--- a/lib/MooX/StrictConstructor.pm
+++ b/lib/MooX/StrictConstructor.pm
@@ -87,8 +87,8 @@ sub _apply_role {
 
 =head2 Inheritance
 
-A class that uses L<MooX::StrictConstructor> but extends another class that
-does not will not be handled properly.  This code hooks into the constructor
+A class that uses L<MooX::StrictConstructor> but extends a non-Moo class will
+not will not be handled properly.  This code hooks into the constructor
 as it is being strung up (literally) and that happens in the parent class,
 not the one using strict.
 
@@ -96,13 +96,6 @@ A class that inherits from a L<Moose> based class will discover that the
 L<Moose> class's attributes are disallowed.  Given sufficient L<Moose> meta
 knowledge it might be possible to work around this.  I'd appreciate pull
 requests and or an outline of a solution.
-
-=head2 Subverting strictness
-
-L<MooseX::StrictConstructor> documents a trick
-for subverting strictness using BUILD.  This does not work here because
-strictness is enforced in the early stage of object construction but the
-BUILD subs are run after the objects has been built.
 
 =head2 Interactions with namespace::clean
 

--- a/lib/MooX/StrictConstructor.pm
+++ b/lib/MooX/StrictConstructor.pm
@@ -107,11 +107,11 @@ BUILD subs are run after the objects has been built.
 =head2 Interactions with namespace::clean
 
 L<MooX::StrictConstructor> creates a C<new> method that L<namespace::clean>
-will over-zealously clean.  Workarounds include using
-L<MooX::StrictConstructor> B<after> L<namespace::autoclean> or telling
+will over-zealously clean.  Workarounds include using L<namespace::autoclean>,
+using L<MooX::StrictConstructor> B<after> L<namespace::clean> or telling
 L<namespace::clean> to ignore C<new> with something like:
 
-  use namespace::clean -except => ['new','meta'];
+  use namespace::clean -except => ['new'];
 
 =head1 SEE ALSO
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -147,12 +147,9 @@ like(
     q{strict subclass from parent that doesn't use strict correctly recognizes bad attribute}
 );
 
-TODO: {
-    local $TODO = "Moose trick.  Doesn't work 'cuz my code runs before object built.";
-    is( exception { Tricky->new( thing => 1, spy => 99 ) },
-        undef,
-        'can work around strict constructor by deleting params in BUILD()' );
-}
+is( exception { Tricky->new( thing => 1, spy => 99 ) },
+    undef,
+    'can work around strict constructor by deleting params in BUILD()' );
 
 is( exception { TrickyBuildArgs->new( thing => 1, spy => 99 ) },
     undef,


### PR DESCRIPTION
This refactors the module to add the checks as part of the BuildAll code, which means it can be effected by deletes in the BUILD subs.  It relies on the constructor generator's buildall_generator method, which was added in Moo 1.004.
